### PR TITLE
Adding commas is error-prone

### DIFF
--- a/resources/testdata/testfile_bugs.m
+++ b/resources/testdata/testfile_bugs.m
@@ -18,3 +18,9 @@ a(1, 1:2) = [3, 1]
 a(3, :) = [3, 1]
 b = zeros(3, 3, 3);
 b(:, :, 2) = rand(2, 2);
+
+ %if AddCommasToMatrices=1
+a=[@(x) minus(x,1),]
+
+%if AddCommasToCellArrays=1
+a={@(x) minus(x,1),  @(x,y) minus(x,y)}


### PR DESCRIPTION
a=[@(x) minus(x,1),]  will produce error code a=[@(x)**,** minus(x,1),]