### PR TITLE
Fix comment after multi-line statement

### DIFF
--- a/MFormatter.m
+++ b/MFormatter.m
@@ -244,7 +244,7 @@ classdef MFormatter < handle
                                     end
                                     
                                 end
-                                line = [line, actCodeFinal(lastEndIndex+1:end), actComment];
+                                line = [line, actCodeFinal(lastEndIndex+1:end), ' ', actComment];
                                 if ~isempty(prevComment)
                                     line = [prevComment, newLine, line];
                                 end
@@ -795,6 +795,7 @@ classdef MFormatter < handle
             
             % Fix semicolon whitespace at end of line
             data = regexprep(data, '\s+;\s*$', ';');
+            data = strtrim(data);
         end
         
         function ret = calculateContainerDepthDeltaOfLine(obj, code)


### PR DESCRIPTION
If you have a comment at the end of a multi-line statement, then that comment would be moved onto a new line instead of leaving it on the same line.

Instead of keeping the formatting of this example:
```
a = {};
a = [a; ...
    'next']; % Comment
```

MBeautifier would convert it into this:
```
a = {};
a = [a; ...
    'next'];
% Comment
```