### PR TITLE
bugfix: MBeautify.formatFiles failed when input directory was a relative path

### DIFF
--- a/MBeautify.m
+++ b/MBeautify.m
@@ -95,7 +95,7 @@ classdef MBeautify
             files = dir(fullfile(directory, fileFilter));
 
             for iF = 1:numel(files)
-                file = fullfile(directory, files(iF).name);
+                file = fullfile(files(iF).folder, files(iF).name);
                 MBeautify.formatFile(file, file);
             end
         end


### PR DESCRIPTION
Tried running MBeautify.formatFiles('test','*.m') from a folder containing a folder test with some m-files in it and MBeautify.formatFile(file, file) failed to find the file that was already found. 

Since dir  provides a struct including the full (absolute) folder path I just replaced directory with that information. In the code all structs in the files array will have the same string as folder so 

I guess the same could be done by adding
`if numel(files) > 0
    directory = files(1).folder
end`

but that would not allow for any future feature that allows multiple directories as input.