### PR TITLE
Fix indentation on MATLAB R2021b

### DIFF
--- a/MBeautify.m
+++ b/MBeautify.m
@@ -221,10 +221,10 @@ classdef MBeautify
             % Save back the modified data then use Matlab samrt indent functionality
             % Set back the selection
             currentEditorPage.Text = [codeBefore, formattedSource, codeAfter];
+            MBeautify.indentPage(currentEditorPage, configuration);
             if ~isempty(selectedPosition)
                 currentEditorPage.goToLine(selectedPosition(1));
             end
-            MBeautify.indentPage(currentEditorPage, configuration);
             currentEditorPage.makeActive();
             
             % Save if it is possible
@@ -260,14 +260,13 @@ classdef MBeautify
             formatter = MBeautifier.MFormatter(configuration);
             currentEditorPage.Text = formatter.performFormatting(currentEditorPage.Text);
             
+            % Use Smart Indent
+            MBeautify.indentPage(currentEditorPage, configuration);
+
             % Set back the selection
             if ~isempty(selectedPosition)
                 currentEditorPage.goToLine(selectedPosition(1));
             end
-            
-            % Use Smart Indent
-            
-            MBeautify.indentPage(currentEditorPage, configuration);
             
             currentEditorPage.makeActive();
             

--- a/MBeautify.m
+++ b/MBeautify.m
@@ -223,7 +223,7 @@ classdef MBeautify
             currentEditorPage.Text = [codeBefore, formattedSource, codeAfter];
             MBeautify.indentPage(currentEditorPage, configuration);
             if ~isempty(selectedPosition)
-                currentEditorPage.goToLine(selectedPosition(1));
+                currentEditorPage.goToPositionInLine(selectedPosition(1), selectedPosition(2));
             end
             currentEditorPage.makeActive();
             
@@ -265,7 +265,7 @@ classdef MBeautify
 
             % Set back the selection
             if ~isempty(selectedPosition)
-                currentEditorPage.goToLine(selectedPosition(1));
+                currentEditorPage.goToPositionInLine(selectedPosition(1), selectedPosition(2));
             end
             
             currentEditorPage.makeActive();

--- a/MBeautify.m
+++ b/MBeautify.m
@@ -193,7 +193,7 @@ classdef MBeautify
             endReached = isequal(lineAfterSelection(1), currentSelection(1));
             expandedSelection = [expandedSelection(1), 1, lineAfterSelection(3), Inf];
             
-            if isequal(currentSelection(1), 1)
+            if isequal(expandedSelection(1), 1)
                 codeBefore = '';
             else
                 codeBeforeSelection = [1, 1, expandedSelection(1), Inf];


### PR DESCRIPTION
In MATLAB R2021b the `MBeautify.formatCurrentEditorPage()` and `MBeautify.formatEditorSelection()` functions didn't indent the code correctly anymore. It seems to be a bug in MathWorks' `editorPage.smartIndentContents()` function which gets triggered depending on the cursor position in the editor.

This pull request fixes the issue by indenting the code before restoring the cursor position. This was anyway a bug in the MBeautifier code, because the smart indentation resets the cursor position, making its prior restoration pointless.

The pull request also contains another improvement to the cursor restoration and a bugfix for the `MBeautify.formatEditorSelection()` function.