### PR TITLE
Feature to preserve inline comment spacing

### DIFF
--- a/+MBeautifier/MFormatter.m
+++ b/+MBeautifier/MFormatter.m
@@ -113,6 +113,10 @@ classdef MFormatter < handle
 
                 %% Determine the position where the line shall be splitted into code and comment
                 [actCode, actComment, splittingPos, isSectionSeparator] = obj.findComment(line);
+                commentSpacing = regexp(actCode, '\s+$', 'match');
+                if numel(commentSpacing) > 0 && actComment ~= "" && obj.Configuration.specialRule('PreserveInlineCommentSpacing').ValueAsDouble() ~= 0
+                    actComment = [commentSpacing{1}, actComment];
+                end
 
                 if isSectionSeparator && formatSectionPrecedingNewlines
                     replacedTextArray = MBeautifier.MFormatter.handleTrailingEmptyLines(replacedTextArray, nSectionPrecedingNewlines);
@@ -237,7 +241,7 @@ classdef MFormatter < handle
                     actCodeFinal = obj.performReplacements(actCode);
                 end
 
-                if ~obj.IsInBlockComment
+                if ~obj.IsInBlockComment && obj.Configuration.specialRule('PreserveInlineCommentSpacing').ValueAsDouble() == 0
                     line = [strtrim(actCodeFinal), ' ', actComment];
                 else
                     line = [strtrim(actCodeFinal), actComment];

--- a/resources/settings/MBeautyConfigurationRules.xml
+++ b/resources/settings/MBeautyConfigurationRules.xml
@@ -253,5 +253,9 @@
          <Key>Indentation_Strategy</Key>
          <Value>NestedFunctions</Value>
       </SpecialRule>
+      <SpecialRule>
+         <Key>PreserveInlineCommentSpacing</Key>
+         <Value>0</Value>
+      </SpecialRule>
    </SpecialRules>
 </MBeautifyRuleConfiguration>


### PR DESCRIPTION
In some cases (for me at least) it makes sense to preserve the spacing for inline comments. Consider the following snippet for example:

```
properties (Dependent, Access=public)
    startFrequency          %> [double] Start Frequency in Hz
    stopFrequency           %> [double] Stop Frequency in Hz
    centerFrequency         %> [double] Center Frequency in Hz
    resolutionBandwidth     %> [double] Resolution Bandwidth in Hz    
    sweepMode               %> [string] Sweep Mode
    refLevOffset            %> [double] Scale the amplitude of reference level in dBm
    nSamples                %> [double] Number of Samplingpoints 
    dBperDiv                %> [double] Scale the amplitude per Division of Y-axis in dB
    attenuationLev          %> [double] Adjust the input attenation in dB
    traceActive             %> [double] Indicates active Trace   
    traceState              %> [string] State of active Trace
end
```

The formatting is nice and tidy, however after applying the normal formatFile to it, it becomes this, which is much less readable imo:

```
properties (Dependent, Access=public)
    startFrequency %> [double] Start Frequency in Hz
    stopFrequency %> [double] Stop Frequency in Hz
    centerFrequency %> [double] Center Frequency in Hz
    resolutionBandwidth %> [double] Resolution Bandwidth in Hz
    sweepMode %> [string] Sweep Mode
    refLevOffset %> [double] Scale the amplitude of reference level in dBm
    nSamples %> [double] Number of Samplingpoints
    dBperDiv %> [double] Scale the amplitude per Division of Y-axis in dB
    attenuationLev %> [double] Adjust the input attenation in dB
    traceActive %> [double] Indicates active Trace
    traceState %> [string] State of active Trace
end
```

Therefore, I added a new special rule `PreserveInlineCommentSpacing` to keep the original spacing in these cases. 

The downside of the solution is that the type of spacing (tabs, spaces) used by the user will also be preserved. I don't really see an easy way to change that, as tabs can represent a variable number of spaces.